### PR TITLE
Updated http reference to a blog

### DIFF
--- a/core/sailing.tab.info
+++ b/core/sailing.tab.info
@@ -15,5 +15,5 @@
     "source": null,
     "size": 455,
     "url": "http://butler.fri.uni-lj.si/datasets/core/sailing.tab",
-    "seealso": ["<a href=https://blog.biolab.si/2017/08/04/its-sailing-time-again>It is sailing time (again)</a>, a blog about preparing a lecture on hierarchical clustering."]
+    "seealso": ["<a href=https://blog.biolab.si/2017/08/11/its-sailing-time-again/>It is sailing time (again)</a>, a blog about preparing a lecture on hierarchical clustering."]
 }


### PR DESCRIPTION
Sailing info was pointing to the missing (old) page in the blog.