### PR TITLE
[FIX][ENH] HTML links

### DIFF
--- a/core/abalone.tab.info
+++ b/core/abalone.tab.info
@@ -6,7 +6,7 @@
     "references": null,
     "seealso": null,
     "size": 191993,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Abalone</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Abalone'>UCI ML Repository</a>",
     "tags": [],
     "target": "numeric",
     "title": "Abalone",

--- a/core/bank-additional.tab.info
+++ b/core/bank-additional.tab.info
@@ -8,7 +8,7 @@
     ],
     "seealso": null,
     "size": 477308,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Bank+Marketing</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Bank+Marketing'>UCI ML Repository</a>",
     "tags": [
         "marketing"
     ],

--- a/core/car.tab.info
+++ b/core/car.tab.info
@@ -5,11 +5,11 @@
     "name": "car",
     "references": [
         "Bohanec M, Rajkovic V (1988) Knowledge acquisition and explanation for multi-attribute decision making. In 8th International Workshop on Expert Systems and their Applications, Avignon, France. pages 59-78.",
-        "Zupan B, Bohanec M, Demsar J, Bratko I (1999) <a href=http://file.biolab.si/papers/1999-Zupan-AIJ.pdf>Learning by discovering concept hierarchies</a>, Artificial Intelligence 109: 211-242."
+        "Zupan B, Bohanec M, Demsar J, Bratko I (1999) <a href='http://file.biolab.si/papers/1999-Zupan-AIJ.pdf'>Learning by discovering concept hierarchies</a>, Artificial Intelligence 109: 211-242."
     ],
     "seealso": null,
     "size": 51939,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Car+Evaluation</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Car+Evaluation'>UCI ML Repository</a>",
     "tags": [
         "synthetic"
     ],

--- a/core/ewba-slovenia-illegal-dumpsites.tab.info
+++ b/core/ewba-slovenia-illegal-dumpsites.tab.info
@@ -13,7 +13,7 @@
     "instances": 13165,
     "missing": true,
     "variables": 25,
-    "source": "<a href=http://register.ocistimo.si>Dumpsite Registry of Slovenia</a>",
+    "source": "<a href='http://register.ocistimo.si'>Dumpsite Registry of Slovenia</a>",
     "url": "http://butler.fri.uni-lj.si/datasets/core/ewba-slovenia-illegal-dumpsites.tab",
     "size": 2907714
 }

--- a/core/foodmart.basket.info
+++ b/core/foodmart.basket.info
@@ -11,7 +11,7 @@
     "instances": 62560,
     "missing": true,
     "variables": 126,
-    "source": "<a href=https://github.com/neo4j-examples/neo4j-foodmart-dataset/tree/master/data>neo4j data repository</a>",
+    "source": "<a href='https://github.com/neo4j-examples/neo4j-foodmart-dataset/tree/master/data'>neo4j data repository</a>",
     "url": "http://butler.fri.uni-lj.si/datasets/core/foodmart.basket",
     "size": 4212566
 }

--- a/core/forestfires.tab.info
+++ b/core/forestfires.tab.info
@@ -4,11 +4,11 @@
     "instances": 517,
     "name": "forestfires",
     "references": [
-        "Cortez P and Morais A (2007) <a href=http://www.dsi.uminho.pt/~pcortez/fires.pdf>A Data Mining Approach to Predict Forest Fires using Meteorological Data</a>. In Proc. of the 13th Portuguese Conference on Artificial Intelligence, Portugal, pp. 512-523."
+        "Cortez P and Morais A (2007) <a href='http://www.dsi.uminho.pt/~pcortez/fires.pdf'>A Data Mining Approach to Predict Forest Fires using Meteorological Data</a>. In Proc. of the 13th Portuguese Conference on Artificial Intelligence, Portugal, pp. 512-523."
     ],
     "seealso": null,
     "size": 32101,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Forest+Fires</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Forest+Fires'>UCI ML Repository</a>",
     "tags": [],
     "target": "numeric",
     "title": "Forest Fires",

--- a/core/hrm-employee-attrition.xlsx.info
+++ b/core/hrm-employee-attrition.xlsx.info
@@ -14,5 +14,5 @@
     "variables": 32,
     "url": "http://butler.fri.uni-lj.si/datasets/core/hrm-employee-attrition.xlsx",
     "size": 262432,
-    "source": "<a href=https://www.ibm.com/communities/analytics/watson-analytics-blog/hr-employee-attrition>IBM Watson Analytics</a>"
+    "source": "<a href='https://www.ibm.com/communities/analytics/watson-analytics-blog/hr-employee-attrition'>IBM Watson Analytics</a>"
 }

--- a/core/iris.tab.info
+++ b/core/iris.tab.info
@@ -10,7 +10,7 @@
     "instances": 150,
     "missing": 0,
     "variables": 5,
-    "source": "<a href=https://archive.ics.uci.edu/ml/datasets/Iris>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/Iris'>UCI ML Repository</a>",
     "size": 4625,
     "url": "http://butler.fri.uni-lj.si/datasets/core/iris.tab",
     "references": [

--- a/core/poker-hand.tab.info
+++ b/core/poker-hand.tab.info
@@ -6,7 +6,7 @@
     "references": null,
     "seealso": null,
     "size": 30302187,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Poker+Hand</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Poker+Hand'>UCI ML Repository</a>",
     "tags": [
         "synthetic"
     ],

--- a/core/slovenia-traffic-accidents-2016-events.tab.info
+++ b/core/slovenia-traffic-accidents-2016-events.tab.info
@@ -14,7 +14,7 @@
     "instances": 17931,
     "missing": true,
     "variables": 18,
-    "source": "<a href=http://www.policija.si/index.php/statistika/prometna-varnost>Archive of Slovene Ministry of Interior</a>",
+    "source": "<a href='http://www.policija.si/index.php/statistika/prometna-varnost'>Archive of Slovene Ministry of Interior</a>",
     "url": "http://butler.fri.uni-lj.si/datasets/core/slovenia-traffic-accidents-2016-events.tab",
     "size": 4501650
 }

--- a/core/slovenia-traffic-accidents-2016-persons.tab.info
+++ b/core/slovenia-traffic-accidents-2016-persons.tab.info
@@ -14,7 +14,7 @@
     "instances": 32857,
     "missing": true,
     "variables": 13,
-    "source": "<a href=http://www.policija.si/index.php/statistika/prometna-varnost>Archive of Slovene Ministry of Interior</a>",
+    "source": "<a href='http://www.policija.si/index.php/statistika/prometna-varnost'>Archive of Slovene Ministry of Interior</a>",
     "url": "http://butler.fri.uni-lj.si/datasets/core/slovenia-traffic-accidents-2016-persons.tab",
     "size": 2915308
 }

--- a/core/slovenian-national-assembly-eng.tab.info
+++ b/core/slovenian-national-assembly-eng.tab.info
@@ -5,10 +5,10 @@
     "name": "slovenian-national-assembly-eng",
     "references": [],
     "seealso": [
-        "<a href=https://blog.biolab.si/2017/09/22/understanding-voting-patterns-at-akos-workshop/>Understanding voting patters at AKOS workshop</a>."
+        "<a href='https://blog.biolab.si/2017/09/22/understanding-voting-patterns-at-akos-workshop/'>Understanding voting patters at AKOS workshop</a>."
     ],
     "size": 18190,
-    "source": "<a href=Parlameter API>https://parlameter.si/</a>",
+    "source": "<a href='https://parlameter.si/'>Parlameter API</a>",
     "tags": [
         "clustering",
         "images",

--- a/core/wine.tab.info
+++ b/core/wine.tab.info
@@ -11,7 +11,7 @@
     "missing": 0,
     "variables": 14,
     "year": "1992",
-    "source": "<a href=https://archive.ics.uci.edu/ml/datasets/Wine>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/Wine'>UCI ML Repository</a>",
     "size": 10991,
     "url": "http://butler.fri.uni-lj.si/datasets/core/wine.tab",
     "seealso": [

--- a/core/winequality-red.tab.info
+++ b/core/winequality-red.tab.info
@@ -8,7 +8,7 @@
     ],
     "seealso": null,
     "size": 84183,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Wine+Quality</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Wine+Quality'>UCI ML Repository</a>",
     "tags": [
         "wine"
     ],

--- a/core/winequality-white.tab.info
+++ b/core/winequality-white.tab.info
@@ -8,7 +8,7 @@
     ],
     "seealso": null,
     "size": 264270,
-    "source": "<a href=UCI ML Repository>http://archive.ics.uci.edu/ml/datasets/Wine+Quality</a>",
+    "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Wine+Quality'>UCI ML Repository</a>",
     "tags": [
         "wine"
     ],

--- a/core/zoo.xlsx.info
+++ b/core/zoo.xlsx.info
@@ -12,7 +12,7 @@
     "instances": 101,
     "missing": false,
     "variables": 17,
-    "source": "<a href=https://archive.ics.uci.edu/ml/datasets/Zoo>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/Zoo'>UCI ML Repository</a>",
     "url": "http://butler.fri.uni-lj.si/datasets/core/zoo.xlsx",
     "size": 50929
 }

--- a/utils/lint.py
+++ b/utils/lint.py
@@ -13,7 +13,7 @@ RE_HREF = """<a href=[^'"]"""
 
 ret = 0
 print('Testing:')
-for infof in glob('**/*.info', recursive=True):
+for infof in sorted(glob('**/*.info', recursive=True)):
     print(infof, end=' ... ')
     with open(infof, 'r') as f:
         d = json.load(f, object_pairs_hook=OrderedDict)


### PR DESCRIPTION
There were multiple problems with with html links:
- several datasets incorrectly used `<a href=name> URL </a>`
- the urls were not quoted and did not render correctly when a trailing `/` was present

Testing was expanded to check that html urls are properly quoted and accessible.
Info files fixed.

For future reference - we expect all html links to be of the following form:
```html
<a href='http://example.com'>Example link</a>
```