### PR TITLE
Fix target specification for no class var

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each data set is described with a record that contains the following attributes:
 * collection: name of original repository
 * references: any references to essential publications of the data set
 * tags: a list of tags
-* target: the type of target class, if any (categorical, numeric, or None)
+* target: the type of target variable ("categorical", "numeric", or null)
 * version:  data set version
 * year: year when the data set was first published
 * instances: number of data instances

--- a/core/slovenian-national-assembly-eng.tab.info
+++ b/core/slovenian-national-assembly-eng.tab.info
@@ -14,7 +14,7 @@
         "images",
         "voting"
     ],
-    "target": "none",
+    "target": null,
     "title": "Slovenian National Assembly",
     "url": "http://butler.fri.uni-lj.si/datasets/core/slovenian-national-assembly-eng.tab",
     "variables": 18,


### PR DESCRIPTION
`null` should be used when data set has no target