### PR TITLE
Add sc directory and a first data set

### DIFF
--- a/sc/buettner-cell-cycle.tab.info
+++ b/sc/buettner-cell-cycle.tab.info
@@ -1,0 +1,19 @@
+{
+    "name": "buettner-cell-cycle",
+    "description": "Single-cell RNA-sequencing data reveals hidden subpopulations of cells",
+    "title": "Cell cyle",
+    "tags": ["single cell"],
+    "version": "1.0",
+    "year": 2015,
+    "collection": "single-cell",
+    "target": "categorical",
+    "instances": 182,
+    "missing": 0,
+    "variables": 564,
+    "source": "<a href='https://www.nature.com/articles/nbt.3102#supplementary-information'>Buettner et. al, 2015, Nature Biotech</a>",
+    "url": "http://butler.fri.uni-lj.si/files/buettner-cell-cycle.tab",
+    "references": [
+        "Buettner et al. (2015) Computational analysis of cell-to-cell heterogeneity in single-cell RNA-sequencing data reveals hidden subpopulations of cells, Nature Biotechnology 33, 155–160."
+    ],
+    "seealso": []
+}


### PR DESCRIPTION
Adds a new dir for single cell data sets.
The plan is to show only data sets from `core` in Orange's Data Sets widget and have a copy of the widget for sc data sets.