### PR TITLE
[FIX] gen_info: Do not add empty prefixes (to match serverfiles)

### DIFF
--- a/gen_info.py
+++ b/gen_info.py
@@ -36,7 +36,11 @@ for root in argv[1:]:
         if changed:
             with open(infof, 'w') as f:
                 json.dump(d, f, indent=4)
-        info.append([[root, filename], d])
+        if root:
+            file_path = [root, filename]
+        else:
+            file_path = [filename]
+        info.append([file_path, d])
 
 info.sort()
 print(json.dumps(info, indent=4))


### PR DESCRIPTION
When one wants to generate the info for current dir an empty prefix can be specified, but it must not be added along with the filename in the file path to match how serverfiles work.