### PR TITLE
lint: Allow more than 1 extension (e.g. foo.tab.gz)

### DIFF
--- a/utils/lint.py
+++ b/utils/lint.py
@@ -18,8 +18,9 @@ for infof in sorted(glob('**/*.info', recursive=True)):
     print(infof, end=' ... ')
     with open(infof, 'r') as f:
         d = json.load(f, object_pairs_hook=OrderedDict)
-        filename = splitext(basename(infof)[:-5])[0]
-        assert filename == d['name'], 'Name field does not match the filename'
+        filename = basename(infof)[:-5]
+        assert (d['name'] and filename.startswith(d['name'])), \
+                'Name field does not match the filename'
         location = d['url']
         try:
             remotefile = urlopen(location)


### PR DESCRIPTION
Instead of using `splitext` and removing just one extension, test only that the file `startswith` the given name.