### PR TITLE
sailing.tab.info: Fix num of variables

### DIFF
--- a/core/sailing.tab.info
+++ b/core/sailing.tab.info
@@ -11,7 +11,7 @@
     "year": "2003",
     "instances": 20,
     "missing": null,
-    "variables": 3,
+    "variables": 4,
     "source": null,
     "size": 455,
     "url": "http://datasets.orange.biolab.si/core/sailing.tab",


### PR DESCRIPTION
`variables` field should include all variables.