### PR TITLE
[FIX] sc: remove Gene ID attribute

### DIFF
--- a/sc/DC_expMatrix_DCnMono.tab.gz.info
+++ b/sc/DC_expMatrix_DCnMono.tab.gz.info
@@ -17,7 +17,7 @@
     ],
     "target": null,
     "title": "Dendritic cells and monocytes in human blood",
-    "url": "http://datasets.orange.biolab.si/sc/DC_expMatrix_DCnMono.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/DC_expMatrix_DCnMono.tab.gz",
     "variables": 26595,
     "num_of_genes": 26593,
     "version": "1.3",

--- a/sc/DC_expMatrix_deeper.characterization.tab.gz.info
+++ b/sc/DC_expMatrix_deeper.characterization.tab.gz.info
@@ -17,7 +17,7 @@
     ],
     "target": null,
     "title": "Dendritic cells and monocytes in human blood (deeper characterization)",
-    "url": "http://datasets.orange.biolab.si/sc/DC_expMatrix_deeper.characterization.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/DC_expMatrix_deeper.characterization.tab.gz",
     "variables": 26595,
     "num_of_genes": 26593,
     "version": "1.3",

--- a/sc/aml-1k.pickle.info
+++ b/sc/aml-1k.pickle.info
@@ -16,7 +16,7 @@
     ],
     "target": "categorical",
     "title": "Bone marrow mononuclear cells with AML (sample)",
-    "url": "http://datasets.orange.biolab.si/sc/aml-1k.pickle",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/aml-1k.pickle",
     "variables": 1004,
     "num_of_genes": 1000,
     "version": "1.3",

--- a/sc/aml-8k.pickle.info
+++ b/sc/aml-8k.pickle.info
@@ -15,7 +15,7 @@
     ],
     "target": "categorical",
     "title": "Bone marrow mononuclear cells with AML",
-    "url": "http://datasets.orange.biolab.si/sc/aml-8k.pickle",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/aml-8k.pickle",
     "variables": 1004,
     "num_of_genes": 1000,
     "version": "1.3",

--- a/sc/ccp_data_Tcells_normCounts.counts.all_genes.tab.gz.info
+++ b/sc/ccp_data_Tcells_normCounts.counts.all_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": null,
     "title": "Cell cycle in T-cells",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_Tcells_normCounts.counts.all_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_Tcells_normCounts.counts.all_genes.tab.gz",
     "variables": 38293,
     "num_of_genes": 38293,
     "version": "1.3",

--- a/sc/ccp_data_Tcells_normCounts.counts.cycle_genes.tab.gz.info
+++ b/sc/ccp_data_Tcells_normCounts.counts.cycle_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": null,
     "title": "Cell cycle in T-cells (cell cycle genes)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_Tcells_normCounts.counts.cycle_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_Tcells_normCounts.counts.cycle_genes.tab.gz",
     "variables": 553,
     "num_of_genes": 553,
     "version": "1.3",

--- a/sc/ccp_data_liver.counts.all_genes.tab.gz.info
+++ b/sc/ccp_data_liver.counts.all_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": null,
     "title": "Cell cycle in mouse liver",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_liver.counts.all_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_liver.counts.all_genes.tab.gz",
     "variables": 20683,
     "num_of_genes": 20683,
     "version": "1.3",

--- a/sc/ccp_data_liver.counts.cycle_genes.tab.gz.info
+++ b/sc/ccp_data_liver.counts.cycle_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": null,
     "title": "Cell cycle in mouse liver (cell cycle genes)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_liver.counts.cycle_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_liver.counts.cycle_genes.tab.gz",
     "variables": 537,
     "num_of_genes": 537,
     "version": "1.3",

--- a/sc/ccp_data_mESCbulk.counts.all_genes.tab.gz.info
+++ b/sc/ccp_data_mESCbulk.counts.all_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (bulk RNA-seq)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_mESCbulk.counts.all_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_mESCbulk.counts.all_genes.tab.gz",
     "variables": 38294,
     "num_of_genes": 38293,
     "version": "1.3",

--- a/sc/ccp_data_mESCbulk.counts.cycle_genes.tab.gz.info
+++ b/sc/ccp_data_mESCbulk.counts.cycle_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (bulk RNA-seq, cell cycle genes)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_data_mESCbulk.counts.cycle_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_data_mESCbulk.counts.cycle_genes.tab.gz",
     "variables": 554,
     "num_of_genes": 553,
     "version": "1.3",

--- a/sc/ccp_normCountsBuettnerEtAl.counts.all_genes.tab.gz.info
+++ b/sc/ccp_normCountsBuettnerEtAl.counts.all_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (Fluidigm)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_normCountsBuettnerEtAl.counts.all_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_normCountsBuettnerEtAl.counts.all_genes.tab.gz",
     "variables": 38294,
     "num_of_genes": 38293,
     "version": "1.3",

--- a/sc/ccp_normCountsBuettnerEtAl.counts.cycle_genes.tab.gz.info
+++ b/sc/ccp_normCountsBuettnerEtAl.counts.cycle_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (Fluidigm, cell cycle genes)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_normCountsBuettnerEtAl.counts.cycle_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_normCountsBuettnerEtAl.counts.cycle_genes.tab.gz",
     "variables": 564,
     "num_of_genes": 563,
     "version": "1.3",

--- a/sc/ccp_normCounts_mESCquartz.counts.all_genes.tab.gz.info
+++ b/sc/ccp_normCounts_mESCquartz.counts.all_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (QuartzSeq)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_normCounts_mESCquartz.counts.all_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_normCounts_mESCquartz.counts.all_genes.tab.gz",
     "variables": 36808,
     "num_of_genes": 36807,
     "version": "1.3",

--- a/sc/ccp_normCounts_mESCquartz.counts.cycle_genes.tab.gz.info
+++ b/sc/ccp_normCounts_mESCquartz.counts.cycle_genes.tab.gz.info
@@ -20,7 +20,7 @@
     ],
     "target": "categorical",
     "title": "Cell cycle in mESC (QuartzSeq, cell cycle genes)",
-    "url": "http://datasets.orange.biolab.si/sc/ccp_normCounts_mESCquartz.counts.cycle_genes.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/ccp_normCounts_mESCquartz.counts.cycle_genes.tab.gz",
     "variables": 562,
     "num_of_genes": 561,
     "version": "1.3",

--- a/sc/cdp_expression_macosko.tab.gz.info
+++ b/sc/cdp_expression_macosko.tab.gz.info
@@ -18,7 +18,7 @@
     ],
     "target": null,
     "title": "Mouse retinal bipolar neurons (DropSeq)",
-    "url": "http://datasets.orange.biolab.si/sc/cdp_expression_macosko.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/cdp_expression_macosko.tab.gz",
     "variables": 6862,
     "num_of_genes": 6860,
     "version": "2.3",

--- a/sc/cdp_expression_shekhar.tab.gz.info
+++ b/sc/cdp_expression_shekhar.tab.gz.info
@@ -18,7 +18,7 @@
     ],
     "target": "categorical",
     "title": "Mouse retinal bipolar neurons (DropSeq, large)",
-    "url": "http://datasets.orange.biolab.si/sc/cdp_expression_shekhar.tab.gz",
+    "url": "https://orange.biolab.si/serverfiles-bio2/temp/cdp_expression_shekhar.tab.gz",
     "variables": 4982,
     "num_of_genes": 4980,
     "version": "1.3",


### PR DESCRIPTION
In #58 'Gene ID' attribute name was not removed from the datasets. This is fixed here.