### PR TITLE
Datasets with new tags

### DIFF
--- a/core/abalone.tab.info
+++ b/core/abalone.tab.info
@@ -7,7 +7,9 @@
     "seealso": null,
     "size": 191993,
     "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Abalone'>UCI ML Repository</a>",
-    "tags": [],
+    "tags": [
+        "biology"
+    ],
     "target": "numeric",
     "title": "Abalone",
     "url": "http://datasets.orange.biolab.si/core/abalone.tab",

--- a/core/bank-additional.tab.info
+++ b/core/bank-additional.tab.info
@@ -10,7 +10,7 @@
     "size": 477308,
     "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Bank+Marketing'>UCI ML Repository</a>",
     "tags": [
-        "marketing"
+        "economy"
     ],
     "target": "categorical",
     "title": "Bank Marketing",

--- a/core/bone-healing.xlsx.info
+++ b/core/bone-healing.xlsx.info
@@ -8,8 +8,8 @@
     "size": 11922,
     "source": null,
     "tags": [
-        "images",
-        "everyone"
+        "image analytics",
+        "biology"
     ],
     "target": "categorical",
     "title": "Bone Healing",

--- a/core/collagen.tab.info
+++ b/core/collagen.tab.info
@@ -4,7 +4,7 @@
     "description": "Data on cells measured with Fourier transform infrared spectroscopy (FTIR) and annotated according to the majority presence of a chemical compound in that part of the cell. Each row represents the data on specific cell, with components of the spectra given in columns. The data was compiled by dr. Christophe Sandt.",
     "collection": "spectral",
     "tags": [
-        "infrared"
+        "spectral"
     ],
     "target": "categorical",
     "version": "1.0",

--- a/core/dicty-development.xlsx.info
+++ b/core/dicty-development.xlsx.info
@@ -10,9 +10,8 @@
     "size": 46639,
     "source": null,
     "tags": [
-        "images",
-        "dictyostelium",
-        "everyone"
+        "image analytics",
+        "biology"
     ],
     "target": "categorical",
     "title": "Development of Social Amoeba",

--- a/core/ewba-slovenia-illegal-dumpsites.tab.info
+++ b/core/ewba-slovenia-illegal-dumpsites.tab.info
@@ -3,8 +3,8 @@
     "title": "Illegal waste dumpsites in Slovenia",
     "description": "Illegal waste dumpsites in Slovenia as tracked by Ecologists Without Borders Association. The data coutains geographical location of the site and its description, including information about accessibility, access type, vaste area and volume and types of waste deposited.",
     "tags": [
-        "location",
-        "date",
+        "geo",
+        "timeseries",
         "ecology"
     ],
     "target": null,

--- a/core/foodmart.basket.info
+++ b/core/foodmart.basket.info
@@ -3,6 +3,8 @@
     "description": "Foodmart 2000 is a market based dataset that came with Microsoft Analysis Services. For every transaction (rows) it contains tuples of item names and number of items bought. Every transaction also contains the store ID.",
     "title": "Foodmart 2000",
     "tags": [
+        "economy",
+        "associate",
         "basket"
     ],
     "target": null,

--- a/core/forestfires.tab.info
+++ b/core/forestfires.tab.info
@@ -9,7 +9,9 @@
     "seealso": null,
     "size": 32101,
     "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Forest+Fires'>UCI ML Repository</a>",
-    "tags": [],
+    "tags": [
+        "ecology"
+    ],
     "target": "numeric",
     "title": "Forest Fires",
     "url": "http://datasets.orange.biolab.si/core/forestfires.tab",

--- a/core/grades-two.tab.info
+++ b/core/grades-two.tab.info
@@ -3,8 +3,8 @@
     "title": "Grades for English and Math",
     "description": "A small data set with final grades from English and Mathematics that was hand-crafted to introduce Euclidean distance and hierarchical clustering.",
     "tags": [
-        "clustering",
-        "synthetic"
+        "synthetic",
+        "educational"
     ],
     "target": null,
     "version": "1.0",

--- a/core/hrm-employee-attrition.xlsx.info
+++ b/core/hrm-employee-attrition.xlsx.info
@@ -3,6 +3,7 @@
     "description": "A fictional data set created by IBM data scientists to demonstrate the use of Watson Analytics. The data reports on factors such as employees' age, gender, salary, job role and satisfaction, and asks to relate these to attrition.",
     "title": "Employee attrition",
     "tags": [
+        "economy",
         "synthetic"
     ],
     "year": 2015,

--- a/core/iris.tab.info
+++ b/core/iris.tab.info
@@ -2,7 +2,9 @@
     "name": "iris",
     "description": "The Iris flower data set or Fisher's Iris data set was introduced by the British statistician and biologist Ronald Fisher in his 1936 paper as an example of linear discriminant analysis. The data on length and width of petal and sepal leafs was actually collected by American botanist Edgar Anderson to quantify the morphologic variation of Iris flowers of three related species.",
     "title": "Iris",
-    "tags": [],
+    "tags": [
+        "biology"
+    ],
     "target": "categorical",
     "version": "1.0",
     "year": 1936,

--- a/core/kickstarter.tab.info
+++ b/core/kickstarter.tab.info
@@ -2,7 +2,9 @@
     "name": "kickstarter",
     "description": "Basic profiling of Kickstarter project pages at the time of the start of the campaign. The class label records if the project was founded. The data is on a small sample of Kickstarter projects whose campaigns started from January to April, 2016. Even though the attributes contain very basic information about the web pages, like the number of videos and images included, it is surprising that these are sufficient for solid prediction of success of the project.",
     "title": "Kickstarter projects",
-    "tags": [],
+    "tags": [
+        "economy"
+    ],
     "year": 2016,
     "target": "categorical",
     "version": "1.0",

--- a/core/oocyte-competence.xlsx.info
+++ b/core/oocyte-competence.xlsx.info
@@ -8,8 +8,8 @@
     "size": 9707,
     "source": null,
     "tags": [
-        "images",
-        "everyone"
+        "image analytics",
+        "biology"
     ],
     "target": "categorical",
     "title": "Mammalian Oocyte Developmental Competence",

--- a/core/retail-basket.tab.info
+++ b/core/retail-basket.tab.info
@@ -3,7 +3,10 @@
     "description": "This is a transnational data set which contains all the transactions occurring between 2010-12-1 and 2011-12-09 for a UK-based and registered non-store online retail. The company mainly sells unique all-occasion gifts. Many customers of the company are wholesalers.",
     "title": "Online Retail",
     "tags": [
-        "marketing"
+        "economy",
+        "timeseries",
+        "geo",
+        "sparse"
     ],
     "target": null,
     "version": "1.0",

--- a/core/sailing.tab.info
+++ b/core/sailing.tab.info
@@ -3,7 +3,6 @@
     "title": "Sailing",
     "description": "Hand-crafted data set to explain inference of classification trees. It records data for Sara, a weekend sailer, and the data before sailing on company, boat type and weather. The class tells if she actually went sailing.",
     "tags": [
-        "tree",
         "synthetic"
     ],
     "target": "categorical",

--- a/core/slovenia-traffic-accidents-2016-events.tab.info
+++ b/core/slovenia-traffic-accidents-2016-events.tab.info
@@ -4,9 +4,8 @@
     "description": "Traffic accidents in Slovenia in year 2016 as published by the Ministry of Internal Affairs. Events (rows) are described through location, cause and type of accident, and road condition. The data on geographic location is provided.",
     "references": [],
     "tags": [
-        "location",
-        "date",
-        "traffic"
+        "geo",
+        "timeseries"
     ],
     "target": null,
     "version": "1.0",

--- a/core/slovenia-traffic-accidents-2016-persons.tab.info
+++ b/core/slovenia-traffic-accidents-2016-persons.tab.info
@@ -4,9 +4,8 @@
     "description": "Persons involved in traffic accidents in Slovenia in year 2016 as published by the Ministry of Internal Affairs. The data includes geographic location of the accident, and profile of a person involved containing the age, gender, type of accident, the result of an alcohol test, and an indicator if the person caused the accident.",
     "references": [],
     "tags": [
-        "location",
-        "date",
-        "traffic"
+        "geo",
+        "timeseries"
     ],
     "target": null,
     "version": "1.0",

--- a/core/slovenian-national-assembly-eng.tab.info
+++ b/core/slovenian-national-assembly-eng.tab.info
@@ -10,9 +10,8 @@
     "size": 18190,
     "source": "<a href='https://parlameter.si/'>Parlameter API</a>",
     "tags": [
-        "clustering",
-        "images",
-        "voting"
+        "image analytics",
+        "politics"
     ],
     "target": null,
     "title": "Slovenian National Assembly",

--- a/core/traffic-signs.tab.info
+++ b/core/traffic-signs.tab.info
@@ -10,7 +10,7 @@
     "size": 3726,
     "source": null,
     "tags": [
-        "images"
+        "image analytics"
     ],
     "target": "categorical",
     "title": "Traffic signs",

--- a/core/winequality-red.tab.info
+++ b/core/winequality-red.tab.info
@@ -9,9 +9,7 @@
     "seealso": null,
     "size": 84183,
     "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Wine+Quality'>UCI ML Repository</a>",
-    "tags": [
-        "wine"
-    ],
+    "tags": [],
     "target": "numeric",
     "title": "Wine quality - red",
     "url": "http://datasets.orange.biolab.si/core/winequality-red.tab",

--- a/core/winequality-white.tab.info
+++ b/core/winequality-white.tab.info
@@ -9,9 +9,7 @@
     "seealso": null,
     "size": 264270,
     "source": "<a href='http://archive.ics.uci.edu/ml/datasets/Wine+Quality'>UCI ML Repository</a>",
-    "tags": [
-        "wine"
-    ],
+    "tags": [],
     "target": "numeric",
     "title": "Wine quality - white",
     "url": "http://datasets.orange.biolab.si/core/winequality-white.tab",

--- a/core/yplp.xlsx.info
+++ b/core/yplp.xlsx.info
@@ -8,8 +8,7 @@
     "size": 93607,
     "source": "<a href='http://yplp.uni-graz.at'>YPL+.db</a>",
     "tags": [
-        "images",
-        "everyone"
+        "image analytics"
     ],
     "target": "categorical",
     "title": "Yeast Protein Localization",

--- a/core/zoo.xlsx.info
+++ b/core/zoo.xlsx.info
@@ -3,7 +3,7 @@
     "title": "Zoo",
     "description": "A dataset created by Richard Forsyth contains seventeen binary-valued attributes that describe animals. Features include information about presence of hair, feathers and teeth, report if animal is aquatic or airborn, and alike. Animals are named and are classified into seven categories: amphibian, bird, fish, insect, invertaebrate, mammal, and reptile.",
     "tags": [
-        "animals"
+        "biology"
     ],
     "target": "categorical",
     "version": "1.0",


### PR DESCRIPTION
I have updated tags in Datasets as [suggested](https://github.com/biolab/orange3/issues/2973#issuecomment-401336016).

- "marketing" becomes "economy", "biology" tag introduced
- if the data set can be used with a particular add-on, add-on name is used as a tag (this is to avoid double-tagging, such as having both "date" and "timeseries" tag)
