### PR TITLE
Some datasets repacked

### DIFF
--- a/sc/aml-1k.tab.gz.info
+++ b/sc/aml-1k.tab.gz.info
@@ -16,7 +16,7 @@
     ],
     "target": "categorical",
     "title": "Bone marrow mononuclear cells with AML (sample)",
-    "url": "http://datasets.orange.biolab.si/sc/aml-1k.pickle",
+    "url": "http://file.biolab.si/datasets/sc/aml-1k.tab.gz",
     "variables": 1004,
     "num_of_genes": 1000,
     "version": "1.3",

--- a/sc/aml-8k.tab.gz.info
+++ b/sc/aml-8k.tab.gz.info
@@ -15,7 +15,7 @@
     ],
     "target": "categorical",
     "title": "Bone marrow mononuclear cells with AML",
-    "url": "http://datasets.orange.biolab.si/sc/aml-8k.pickle",
+    "url": "http://file.biolab.si/datasets/sc/aml-8k.tab.gz",
     "variables": 1004,
     "num_of_genes": 1000,
     "version": "1.3",

--- a/sc/pbmc_kang2018_raw_control.pkl.gz.info
+++ b/sc/pbmc_kang2018_raw_control.pkl.gz.info
@@ -16,7 +16,7 @@
     "variables": 35637,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE96583'>GEO</a>",
     "size": 19670012,
-    "url": "http://datasets.orange.biolab.si/sc/pbmc_kang2018_raw_control.pkl.gz",
+    "url": "http://file.biolab.si/datasets/sc/pbmc_kang2018_raw_control.pkl.gz",
     "references": [
         "Kang, H. M., Subramaniam, M., Targ, S., Nguyen, M., Maliskova, L., McCarthy, E., ... & Gate, R. E. (2018). Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nature biotechnology, 36(1), 89.",
         "Butler, A., Hoffman, P., Smibert, P., Papalexi, E., & Satija, R. (2018). Integrating single-cell transcriptomic data across different conditions, technologies, and species. Nature biotechnology, 36(5), 411."

--- a/sc/pbmc_kang2018_raw_stimulated.pkl.gz.info
+++ b/sc/pbmc_kang2018_raw_stimulated.pkl.gz.info
@@ -16,7 +16,7 @@
     "variables": 35637,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE96583'>GEO</a>",
     "size": 20096165,
-    "url": "http://datasets.orange.biolab.si/sc/pbmc_kang2018_raw_stimulated.pkl.gz",
+    "url": "http://file.biolab.si/datasets/sc/pbmc_kang2018_raw_stimulated.pkl.gz",
     "references": [
         "Kang, H. M., Subramaniam, M., Targ, S., Nguyen, M., Maliskova, L., McCarthy, E., ... & Gate, R. E. (2018). Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nature biotechnology, 36(1), 89.",
         "Butler, A., Hoffman, P., Smibert, P., Papalexi, E., & Satija, R. (2018). Integrating single-cell transcriptomic data across different conditions, technologies, and species. Nature biotechnology, 36(5), 411."

--- a/sc/pbmc_kang2018_sample.tab.gz.info
+++ b/sc/pbmc_kang2018_sample.tab.gz.info
@@ -1,5 +1,5 @@
 {
-    "name": "pbmc_kang2018_sample.pkl.gz",
+    "name": "pbmc_kang2018_sample.tab.gz",
     "description": "A preprocessed sample of Kang et al. (2018) data containing 1,000 controls and stimulated cells and 1,500 highly variable genes. Expression was CPM-normalized, log-transformed, and z-standardized. In the original study, the multiplexed dscRNA-seq was used to characterize the cell-type specificity and inter-individual variability of response to IFN-\u03b2, a potent cytokine that induces genome-scale changes in the transcriptional profiles of immune cells. From each of eight lupus patients, PBMCs were activated with recombinant IFN-\u03b2 or left untreated for 6 h, a time point previously found to maximize the expression of interferon-sensitive genes in dendritic cells and T cells16,17. Two pools, IFN-\u03b2-treated and control, were prepared with the same number of cells from each individual and loaded onto the 10\u00d7 Chromium instrument.",
     "title": "Stimulated and resting immune cells (sample)",
     "tags": [
@@ -15,7 +15,7 @@
     "instances": 1000,
     "variables": 1502,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE96583'>GEO</a>",
-    "url": "http://datasets.orange.biolab.si/sc/pbmc_kang2018_sample.pkl.gz",
+    "url": "http://file.biolab.si/datasets/sc/pbmc_kang2018_sample.tab.gz",
     "references": [
         "Kang, H. M., Subramaniam, M., Targ, S., Nguyen, M., Maliskova, L., McCarthy, E., ... & Gate, R. E. (2018). Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nature biotechnology, 36(1), 89.",
         "Butler, A., Hoffman, P., Smibert, P., Papalexi, E., & Satija, R. (2018). Integrating single-cell transcriptomic data across different conditions, technologies, and species. Nature biotechnology, 36(5), 411."


### PR DESCRIPTION
#### Issue 

Fixes https://github.com/biolab/orange3/issues/3799

#### Description

- Pickle AML datasets were repacked to tab.gz. since they are small. 
- `pbmc_kang2018_sample` repacked to `tab.gz`since it is small.
- `pbmc_kang2018_raw_stimulated` and `pbmc_kang2018_raw_control` repacked pickle.