### PR TITLE
Add baron2016 and xin2016 data sets along with samples

### DIFF
--- a/sc/baron2016_pancreas_human.pkl.gz.info
+++ b/sc/baron2016_pancreas_human.pkl.gz.info
@@ -1,0 +1,25 @@
+{
+    "name": "baron2016_pancreas_human.pkl.gz",
+    "description": "Cells captured obtained using a droplet-based single-cell RNA-Seq method, to determine the transcriptomes of over 12,000 individual pancreatic cells from  four human donors. Cells could be divided into 15 clusters that matched previously characterized cell types: all endocrine cell types, including rare ghrelin-expressing epsilon-cells, exocrine cell types, vascular cells, Schwann cells, quiescent and activated pancreatic stellate cells, and four types of immune cells.",
+    "title": "Pancreas cells in human",
+    "tags": [
+        "human",
+        "expression",
+        "pancreas"
+    ],
+    "target": "categorical",
+    "version": "1.0",
+    "year": 2016,
+    "collection": "GEO",
+    "instances": 8569,
+    "variables": 20125,
+    "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE84133'>GEO</a>",
+    "url": "http://file.biolab.si/scdata/baron2016_pancreas_human.pkl.gz",
+    "references": [
+"Baron, M., Veres, A., Wolock, S. L., Faust, A. L., Gaujoux, R., Vetere, A., ... & Melton, D. A. (2016). A single-cell transcriptomic map of the human and mouse pancreas reveals inter-and intra-cell population structure. Cell systems, 3(4), 346-360."
+    ],
+    "seealso": [],
+    "taxid": "10090",
+    "num_of_genes": 20128,
+    "size": 22304718
+}

--- a/sc/baron2016_xin2016_pancreas_human_sample.pkl.gz.info
+++ b/sc/baron2016_xin2016_pancreas_human_sample.pkl.gz.info
@@ -1,0 +1,26 @@
+{
+    "name": "baron2016_xin2016_pancreas_human_sample.pkl.gz",
+    "description": "Pancreatic cells originating from two data sets obtained using different experimental protocols exhibit substantial batch effects. The cells are samples from studies by Xin et al. and Baron et al. and contain major pancreatic cell types.",
+    "title": "Pancreatic cells from two experimental studies",
+    "tags": [
+        "human",
+        "expression",
+        "pancreas"
+    ],
+    "target": "categorical",
+    "version": "1.0",
+    "year": 2016,
+    "collection": "GEO",
+    "instances": 2131,
+    "variables": 19548,
+    "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM2230759'>Baron et al.</a>&nbsp;<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE81608'>Xin et al.</a>",
+    "url": "http://file.biolab.si/scdata/baron2016_xin2016_pancreas_human.pkl.gz",
+    "references": [
+"Baron, M., Veres, A., Wolock, S. L., Faust, A. L., Gaujoux, R., Vetere, A., ... & Melton, D. A. (2016). A single-cell transcriptomic map of the human and mouse pancreas reveals inter-and intra-cell population structure. Cell systems, 3(4), 346-360.",
+"Xin, Y, Kim, J., Okamoto, H., Ni, M., Wei, Y., Adler, C., J. Murphy, A., D. Yancopoulos, Lin, C., Gromada, J. (2016). RNA Sequencing of Single Human Islet Cells Reveals Type 2 Diabetes Genes. Cell Metabolism, 24 (4), 608-615."
+    ],
+    "seealso": [],
+    "taxid": "10090",
+    "num_of_genes": 19548,
+    "size": 18021305
+}

--- a/sc/xin2016_pancreas_human.pkl.gz.info
+++ b/sc/xin2016_pancreas_human.pkl.gz.info
@@ -1,0 +1,27 @@
+{
+    "name": "xin2016_pancreas_human.pkl.gz",
+    "description": "Data gathered using single-cell RNA sequencing to determine the transcriptomes of 1,492 human pancreatic α-, β-, δ- and PP cells from non-diabetic and type 2 diabetes organ donors. 245 genes with disturbed expression in type 2 diabetes can be idenfitied from it.",
+    "title": "Pancreas cells in human (type 2 diabetis)",
+    "tags": [
+        "human",
+        "expression",
+        "pancreas",
+        "diabetes"
+    ],
+    "target": "categorical",
+    "version": "1.0",
+    "year": 2016,
+    "collection": "GEO",
+    "instances": 1492,
+    "variables": 39851,
+    "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE81608'>GEO</a>",
+    "url": "http://file.biolab.si/scdata/xin2016_pancreas_human.pkl.gz",
+    "references": [
+"Xin, Y, Kim, J., Okamoto, H., Ni, M., Wei, Y., Adler, C., J. Murphy, A., D. Yancopoulos, Lin, C., Gromada, J. (2016). RNA Sequencing of Single Human Islet Cells Reveals Type 2 Diabetes Genes. Cell Metabolism, 24 (4), 608-615."
+
+    ],
+    "seealso": [],
+    "taxid": "10090",
+    "num_of_genes": 39851,
+    "size": 45214425
+}


### PR DESCRIPTION
This adds a data set containing pancreatic cells from Xin et al. 2016 and Baron et al. Additionally, it contains one data set containing a sample of cells from both data sets in order to demonstrate batch effects and how we can combat them.