### PR TITLE
Remove lowly-expressed genes in pancreas samples

### DIFF
--- a/sc/baron2016_pancreas_human_sample.tab.gz.info
+++ b/sc/baron2016_pancreas_human_sample.tab.gz.info
@@ -1,5 +1,5 @@
 {
-    "name": "baron2016_pancreas_human_sample.tab.gz",
+    "name": "baron2016_pancreas_human_sample",
     "description": "A sample of transcriptomes of major pancreatic cell types from one human donor.",
     "title": "Pancreas cells in human samples",
     "tags": [
@@ -8,18 +8,18 @@
         "pancreas"
     ],
     "target": "categorical",
-    "version": "1.0",
+    "version": "2.0",
     "year": 2016,
     "collection": "GEO",
     "instances": 1631,
-    "variables": 20125,
+    "variables": 15279,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE84133'>GEO</a>",
-    "url": "https://datasets.biolab.si/sc/baron2016_pancreas_human_sample.tab.gz",
+    "url": "http://file.biolab.si/scdata/baron2016_pancreas_human_sample.tab.gz",
     "references": [
         "Baron, M., Veres, A., Wolock, S. L., Faust, A. L., Gaujoux, R., Vetere, A., ... & Melton, D. A. (2016). A single-cell transcriptomic map of the human and mouse pancreas reveals inter-and intra-cell population structure. Cell systems, 3(4), 346-360."
     ],
     "seealso": [],
     "taxid": "9606",
-    "num_of_genes": 20053,
-    "size": 4381437
+    "num_of_genes": 15279,
+    "size": 4827070
 }

--- a/sc/xin2016_pancreas_human_sample.tab.gz.info
+++ b/sc/xin2016_pancreas_human_sample.tab.gz.info
@@ -1,5 +1,5 @@
 {
-    "name": "xin2016_pancreas_human_sample.tab.gz",
+    "name": "xin2016_pancreas_human_sample",
     "description": "A sample of 500 single cells gathered using single-cell RNA sequencing to determine the transcriptomes of human pancreatic \u03b1-, \u03b2-, \u03b4- and PP cells from non-diabetic and type 2 diabetes organ donors. 245 genes with disturbed expression in type 2 diabetes can be idenfitied from it.",
     "title": "Pancreas cells in human (type 2 diabetes) sample",
     "tags": [
@@ -9,18 +9,18 @@
         "diabetes"
     ],
     "target": "categorical",
-    "version": "1.0",
+    "version": "2.0",
     "year": 2016,
     "collection": "GEO",
     "instances": 500,
-    "variables": 39851,
+    "variables": 26413,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE81608'>GEO</a>",
-    "url": "https://datasets.biolab.si/sc/xin2016_pancreas_human_sample.tab.gz",
+    "url": "http://file.biolab.si/scdata/xin2016_pancreas_human_sample.tab.gz",
     "references": [
         "Xin, Y, Kim, J., Okamoto, H., Ni, M., Wei, Y., Adler, C., J. Murphy, A., D. Yancopoulos, Lin, C., Gromada, J. (2016). RNA Sequencing of Single Human Islet Cells Reveals Type 2 Diabetes Genes. Cell Metabolism, 24 (4), 608-615."
     ],
     "seealso": [],
     "taxid": "9606",
-    "num_of_genes": 35899,
-    "size": 24493444
+    "num_of_genes": 26413,
+    "size": 24993590
 }


### PR DESCRIPTION
This removes a lot of columns from each of the pancreas Xin2016 and Baron2016 samples, about 14k, and 5k, respectively. Curiously enough, the gzipped file size ends up being _larger_ than before...