### PR TITLE
Fix number of variables for pancreas sample data sets

### DIFF
--- a/sc/baron2016_pancreas_human_sample.tab.gz.info
+++ b/sc/baron2016_pancreas_human_sample.tab.gz.info
@@ -8,11 +8,11 @@
         "pancreas"
     ],
     "target": "categorical",
-    "version": "2.0",
+    "version": "2.1",
     "year": 2016,
     "collection": "GEO",
     "instances": 1631,
-    "variables": 15279,
+    "variables": 15284,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE84133'>GEO</a>",
     "url": "http://file.biolab.si/scdata/baron2016_pancreas_human_sample.tab.gz",
     "references": [

--- a/sc/xin2016_pancreas_human_sample.tab.gz.info
+++ b/sc/xin2016_pancreas_human_sample.tab.gz.info
@@ -9,11 +9,11 @@
         "diabetes"
     ],
     "target": "categorical",
-    "version": "2.0",
+    "version": "2.1",
     "year": 2016,
     "collection": "GEO",
     "instances": 500,
-    "variables": 26413,
+    "variables": 26414,
     "source": "<a href='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE81608'>GEO</a>",
     "url": "http://file.biolab.si/scdata/xin2016_pancreas_human_sample.tab.gz",
     "references": [


### PR DESCRIPTION
Fixes the number of variables for pancreas sample data sets.

@lanzagar Unfortunately, [`domain.variables`](https://github.com/biolab/orange3/blob/master/Orange/data/domain.py#L151) only includes the attributes and class vars, no metas.