### PR TITLE
corrected image address column in data file

### DIFF
--- a/core/dicty-development.xlsx.info
+++ b/core/dicty-development.xlsx.info
@@ -9,7 +9,7 @@
     "target": "categorical",
     "size": 46639,
     "year": 2018,
-    "version": "1.0",
+    "version": "1.1",
     "tags": [
         "image analytics",
         "biology"

--- a/core/dicty-development.xlsx.info
+++ b/core/dicty-development.xlsx.info
@@ -18,6 +18,6 @@
         "Li CL, Santhanam B, Webb AN, Zupan B, Shaulsky G (2016) Gene discovery by chemical mutagenesis and whole-genome sequencing in Dictyostelium. Genome Res 26(9):1268-76."
     ],
     "source": "",
-    "url": "https://datasets.biolab.si/core/dicty-development.xlsx",
+    "url": "http://file.biolab.si/tmp/dicty-development.xlsx",
     "seealso": []  
 }


### PR DESCRIPTION
Previous data file in Excel format included formulas, which were now replaced with values. Orange should now display the images correctly, whereas in the previous data file the links to images were broken.