### PR TITLE
Monks Problems: Update source URL

### DIFF
--- a/core/monks-1.tab.info
+++ b/core/monks-1.tab.info
@@ -16,7 +16,7 @@
     "references": [
         "The MONK's Problems - A Performance Comparison of Different Learning Algorithms, by S.B. Thrun, J. Bala, E. Bloedorn, I. Bratko, B. Cestnik, J. Cheng, K. De Jong, S. Dzeroski, S.E. Fahlman, D. Fisher, R. Hamann, K. Kaufman, S. Keller, I. Kononenko, J. Kreuziger, R.S. Michalski, T. Mitchell, P. Pachowicz, Y. Reich H. Vafaie, W. Van de Welde, W. Wenzel, J. Wnek, and J. Zhang. Technical Report CS-CMU-91-197, Carnegie Mellon University, Dec. 1991."
     ],
-    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems'>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/dataset/70/monk+s+problems'>UCI ML Repository</a>",
     "url": "https://datasets.biolab.si/core/monks-1.tab",
     "seealso": []
 }

--- a/core/monks-2.tab.info
+++ b/core/monks-2.tab.info
@@ -16,7 +16,7 @@
     "references": [
         "The MONK's Problems - A Performance Comparison of Different Learning Algorithms, by S.B. Thrun, J. Bala, E. Bloedorn, I. Bratko, B. Cestnik, J. Cheng, K. De Jong, S. Dzeroski, S.E. Fahlman, D. Fisher, R. Hamann, K. Kaufman, S. Keller, I. Kononenko, J. Kreuziger, R.S. Michalski, T. Mitchell, P. Pachowicz, Y. Reich H. Vafaie, W. Van de Welde, W. Wenzel, J. Wnek, and J. Zhang. Technical Report CS-CMU-91-197, Carnegie Mellon University, Dec. 1991."
     ],
-    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems'>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/dataset/70/monk+s+problems'>UCI ML Repository</a>",
     "url": "https://datasets.biolab.si/core/monks-2.tab",
     "seealso": []
 }

--- a/core/monks-3.tab.info
+++ b/core/monks-3.tab.info
@@ -16,7 +16,7 @@
     "references": [
         "The MONK's Problems - A Performance Comparison of Different Learning Algorithms, by S.B. Thrun, J. Bala, E. Bloedorn, I. Bratko, B. Cestnik, J. Cheng, K. De Jong, S. Dzeroski, S.E. Fahlman, D. Fisher, R. Hamann, K. Kaufman, S. Keller, I. Kononenko, J. Kreuziger, R.S. Michalski, T. Mitchell, P. Pachowicz, Y. Reich H. Vafaie, W. Van de Welde, W. Wenzel, J. Wnek, and J. Zhang. Technical Report CS-CMU-91-197, Carnegie Mellon University, Dec. 1991."
     ],
-    "source": "<a href='https://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems'>UCI ML Repository</a>",
+    "source": "<a href='https://archive.ics.uci.edu/dataset/70/monk+s+problems'>UCI ML Repository</a>",
     "url": "https://datasets.biolab.si/core/monks-3.tab",
     "seealso": []
 }


### PR DESCRIPTION
Lint is failing due to (supposedly) changed URL for Monks on UCI repository.