### PR TITLE
add Fairness datasets

### DIFF
--- a/core/adult.tab.info
+++ b/core/adult.tab.info
@@ -15,7 +15,7 @@
         "fairness"
     ],
     "references": [
-        "Ron Kohavi (1996) Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid. AProceedings of the Second International Conference on Knowledge Discovery and Data Mining."
+        "Ron Kohavi (1996) Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid. Proceedings of the Second International Conference on Knowledge Discovery and Data Mining."
     ],
     "source": "<a href='https://archive.ics.uci.edu/ml/datasets/adult'>UCI ML Repository</a>",
     "url": "https://www.dropbox.com/scl/fi/oyddsxe0pliwf4bw6ge97/adult.tab?rlkey=bkvuye7lpxepvsvrwx2f34jfz&dl=1",

--- a/core/adult.tab.info
+++ b/core/adult.tab.info
@@ -1,22 +1,23 @@
 {
     "collection": "UCI",
-    "description": "Extraction was done by Barry Becker from the 1994 Census database. A set of reasonably clean records was extracted using the following conditions: ((AAGE>16) && (AGI>100) && (AFNLWGT>1)&& (HRSWK>0)). Prediction task is to determine whether a person makes over 50K a year.",
+    "description": "Data extracted by Barry Becker from the 1994 Census database so that ((AAGE>16) & (AGI>100) & (AFNLWGT>1) & (HRSWK>0)). The prediction task is determining whether a person makes over 50K yearly. Regarding fairness, \"sex\" is frequently considered the protected attribute, with \"male\" as the privileged value. Similarly, \"race\" and \"age\" can be treated as protected attributes. For \"race,\" \"white\" is the privileged value, and for \"age,\" the specified group is between 25 and 60 years.",
     "name": "adult",
     "title": "Adult",
     "instances": 32561,
     "variables": 15,
     "missing": true,
     "target": "categorical",
-    "size": 4301202,
+    "size": 4333819,
     "year": 1996,
     "version": "1.0",
     "tags": [
-        "economy"
+        "economy",
+        "fairness"
     ],
     "references": [
         "Ron Kohavi (1996) Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid. AProceedings of the Second International Conference on Knowledge Discovery and Data Mining."
     ],
     "source": "<a href='https://archive.ics.uci.edu/ml/datasets/adult'>UCI ML Repository</a>",
-    "url": "https://datasets.biolab.si/core/adult.tab",
+    "url": "https://www.dropbox.com/scl/fi/oyddsxe0pliwf4bw6ge97/adult.tab?rlkey=bkvuye7lpxepvsvrwx2f34jfz&dl=1",
     "seealso": []
 }

--- a/core/compas-scores-two-years.tab.info
+++ b/core/compas-scores-two-years.tab.info
@@ -1,0 +1,24 @@
+{
+    "collection": "ProPublica",
+    "description": "With the COMPAS dataset, we can predict the likelihood of a defendant becoming a recidivist. The data contains various attributes: age, race, sex, priors count, charge degree, and more. The data was, in detail, analyzed by ProPublica, which identified racial disparities in its predictions. We have included all date/time features as meta attributes. When addressing fairness, \"race\" is often considered the protected attribute, with \"Caucasian\" being the privileged value. In some studies, \"sex\" is also treated as the protected attribute, designating \"female\" as the privileged value.",
+    "name": "compas-scores-two-years",
+    "title": "COMPAS Analysis",
+    "instances": 7214,
+    "variables": 52,
+    "missing": true,
+    "target": "categorical",
+    "size": 2786914,
+    "year": 2014,
+    "version": "1.0",
+    "tags": [
+        "criminal justice",
+        "fairness"
+    ],
+    "references": [
+        "https://www.propublica.org/article/machine-bias-risk-assessments-in-criminal-sentencing/",
+        "https://www.propublica.org/article/how-we-analyzed-the-compas-recidivism-algorithm/"
+    ],
+    "source": "<a href='https://github.com/propublica/compas-analysis'>ProPublica GitHub Repository</a>",
+    "url": "https://www.dropbox.com/scl/fi/9grj1t0mhzblhtp5z0rxf/compas-scores-two-years.tab?rlkey=axe6q07zcx98cesdwfzeli8a4&dl=1",
+    "seealso": []
+}

--- a/core/german-credit-data.tab.info
+++ b/core/german-credit-data.tab.info
@@ -1,7 +1,7 @@
 {
     "collection": "UCI",
     "description": "The data categorizes individuals, based on various attributes, into good or bad credit risks. Attributes contain categorical and numeric features such as age, job, credit history, and personal status. In classification, misclassifying a \"bad\" customer as \"good\" is more problematic than misclassifying a good customer as bad. Regarding fairness, \"sex\" is the protected attribute, with \"male\" as the privileged value. Additionally, we can regard age as a protected attribute after binarizing it into two groups: <=25 and >25 years old.",
-    "name": "statlog-german-credit-data",
+    "name": "german-credit-data",
     "title": "German Credit Data",
     "instances": 1000,
     "variables": 21,

--- a/core/german-credit-data.tab.info
+++ b/core/german-credit-data.tab.info
@@ -1,6 +1,6 @@
 {
     "collection": "UCI",
-    "description": "The data categorizes individuals, based on various attributes, into good or bad credit risks. Attributes contain categorical and numeric features such as age, job, credit history, and personal status. In classification, misclassifying a \"bad\" customer as \"good\" is more problematic than misclassifying a good customer as bad. Regarding fairness, \"sex\" is the protected attribute, with \"male\" as the privileged value. Additionally, we can regard age as a protected attribute after binarizing it into two groups: <=25 and >25 years old."
+    "description": "The data categorizes individuals, based on various attributes, into good or bad credit risks. Attributes contain categorical and numeric features such as age, job, credit history, and personal status. In classification, misclassifying a \"bad\" customer as \"good\" is more problematic than misclassifying a good customer as bad. Regarding fairness, \"sex\" is the protected attribute, with \"male\" as the privileged value. Additionally, we can regard age as a protected attribute after binarizing it into two groups: <=25 and >25 years old.",
     "name": "statlog-german-credit-data",
     "title": "German Credit Data",
     "instances": 1000,

--- a/core/german-credit-data.tab.info
+++ b/core/german-credit-data.tab.info
@@ -1,0 +1,23 @@
+{
+    "collection": "UCI",
+    "description": "The data categorizes individuals, based on various attributes, into good or bad credit risks. Attributes contain categorical and numeric features such as age, job, credit history, and personal status. In classification, misclassifying a \"bad\" customer as \"good\" is more problematic than misclassifying a good customer as bad. Regarding fairness, \"sex\" is the protected attribute, with \"male\" as the privileged value. Additionally, we can regard age as a protected attribute after binarizing it into two groups: <=25 and >25 years old."
+    "name": "statlog-german-credit-data",
+    "title": "German Credit Data",
+    "instances": 1000,
+    "variables": 21,
+    "missing": false,
+    "target": "categorical",
+    "size": 182882,
+    "year": 1994,
+    "version": "1.0",
+    "tags": [
+        "finance",
+        "fairness"
+    ],
+    "references": [
+        "Hofmann,Hans. (1994). Statlog (German Credit Data). UCI Machine Learning Repository. https://doi.org/10.24432/C5NC77."
+    ],
+    "source": "<a href='http://archive.ics.uci.edu/dataset/144/statlog+german+credit+data'>UCI ML Repository</a>",
+    "url": "https://www.dropbox.com/scl/fi/xavrluuxo3g0j9jm8679l/german-credit-data.tab?rlkey=plnegt8034f2gwkby8vpn5kys&dl=1",
+    "seealso": []
+}

--- a/core/hdi-edu.tab.info
+++ b/core/hdi-edu.tab.info
@@ -1,6 +1,6 @@
 {
     "collection": "UNDP Human Development Reports",
-    "description": "The Human Development Index (HDI) is a summary measure of average achievement in key dimensions of human development: a long and healthy life, knowledge, and decent living. The data includes HDI as reported in 2015 and selected related socioeconomic from countries worldwide. We have removed HDI-related variables and countries with a missing HDI score. This dataset is used in the "Socio-economic characteristics of countries" activity on the pumice.si website.",
+    "description": "The Human Development Index (HDI) is a summary measure of average achievement in key dimensions of human development: a long and healthy life, knowledge, and decent living. The data includes HDI as reported in 2015 and selected related socioeconomic from countries worldwide. We have removed HDI-related variables and countries with a missing HDI score. This dataset is used in the \"Socio-economic characteristics of countries\" activity on the pumice.si website.",
     "name": "hdi-edu",
     "title": "HDI-edu",
     "instances": 188,


### PR DESCRIPTION
Added two fairness datasets: COMPAS Analysis and German Credit Data.
Modified Adult datasets, to include fairness attributes.