### PR TITLE
add ParlaMintGB-1000 dataset

### DIFF
--- a/core/ParlaMint-1000.tab.info
+++ b/core/ParlaMint-1000.tab.info
@@ -1,0 +1,23 @@
+{
+    "name": "ParlaMint-1000",
+    "title": "ParlaMint",
+    "description": "A sample of 1000 parliamentary debates from the ParlaMint-GB corpus. ParlaMint-GB features speeches from both houses of the parliament for years 2019 and 2020. It comes with rich metadata, such as speaker name, party affiliation, and speaker role.",
+    "references": [
+        "Tomaž Erjavec et al. The ParlaMint corpora of parliamentary proceedings. Language Resources and Evaluation, 2022. https://doi.org/10.1007/s10579-021-09574-0"
+    ],
+    "tags": [
+        "text",
+        "classification",
+        "time",
+        "politics"
+    ],
+    "target": "categorical",
+    "version": "2.1",
+    "year": 2021,
+    "instances": 1000,
+    "missing": true,
+    "variables": 17,
+    "source": "https://github.com/clarin-eric/ParlaMint/blob/main/Samples/ParlaMint-GB/ParlaMint-GB.ana.xml",
+    "url": "http://file.biolab.si/files/datasets/ParlaMintGB-1000.tab",
+    "size": 1741633
+}


### PR DESCRIPTION
Add a sample of 1000 instances of ParlaMint-GB data used for text mining (topic modeling, LDA w/ 5 topics). Version is stated as 2.1 to comply with the original versioning of this corpus.