### PR TITLE
Remove class from Philadelphia

### DIFF
--- a/core/philadelphia-crime.csv.xz.info
+++ b/core/philadelphia-crime.csv.xz.info
@@ -6,7 +6,7 @@
     "instances": 9666,
     "variables": 4,
     "missing": false,
-    "target": "categorical",
+    "target": "",
     "size": 92660,
     "year": 2016,
     "version": "1.0",


### PR DESCRIPTION
Philadelphia does not, in fact, have a target variable. Remove it from info.