### PR TITLE
Changes to adult dataset, fixed COMPAS dataset references

### DIFF
--- a/core/adult.tab.info
+++ b/core/adult.tab.info
@@ -1,15 +1,15 @@
 {
     "collection": "UCI",
-    "description": "Data extracted by Barry Becker from the 1994 Census database so that ((AAGE>16) & (AGI>100) & (AFNLWGT>1) & (HRSWK>0)). The prediction task is determining whether a person makes over 50K yearly. Regarding fairness, \"sex\" is frequently considered the protected attribute, with \"male\" as the privileged value. Similarly, \"race\" and \"age\" can be treated as protected attributes. For \"race,\" \"white\" is the privileged value, and for \"age,\" the specified group is between 25 and 60 years.",
+    "description": "Data extracted by Barry Becker from the 1994 Census database so that ((AAGE>16) & (AGI>100) & (AFNLWGT>1) & (HRSWK>0)). The prediction task is determining whether a person makes over 50K yearly. Regarding fairness, \"gender\" is frequently considered the protected attribute, with \"Male\" as the privileged value. Similarly, \"race\" and \"age\" can be treated as protected attributes. For \"race,\" \"Caucasian\" is the privileged value, and for \"age,\" the specified group is between 25 and 60 years.",
     "name": "adult",
-    "title": "Adult",
-    "instances": 32561,
+    "title": "Adult Census Income",
+    "instances": 48842,
     "variables": 15,
     "missing": true,
     "target": "categorical",
-    "size": 4301256,
+    "size": 5860112,
     "year": 1996,
-    "version": "1.1",
+    "version": "1.2",
     "tags": [
         "economy",
         "fairness"
@@ -18,6 +18,6 @@
         "Ron Kohavi (1996) Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid. Proceedings of the Second International Conference on Knowledge Discovery and Data Mining."
     ],
     "source": "<a href='https://archive.ics.uci.edu/ml/datasets/adult'>UCI ML Repository</a>",
-    "url": "https://datasets.biolab.si/core/adult.tab",
+    "url": "https://www.dropbox.com/scl/fi/r41ysj8umr52fwsl2qvb2/adult.tab?rlkey=wb2tt99zq9b84z8nxbx6yhg2b&dl=1",
     "seealso": []
 }

--- a/core/compas-scores-two-years.tab.info
+++ b/core/compas-scores-two-years.tab.info
@@ -15,8 +15,8 @@
         "fairness"
     ],
     "references": [
-        "https://www.propublica.org/article/machine-bias-risk-assessments-in-criminal-sentencing/",
-        "https://www.propublica.org/article/how-we-analyzed-the-compas-recidivism-algorithm/"
+        "Angwin, J., Larson, J., Mattu, S., & Kirchner, L. (2016). <a href='https://www.propublica.org/article/machine-bias-risk-assessments-in-criminal-sentencing/'>Machine Bias.</a> ProPublica.",
+        "Larson, J., Mattu, S., Kirchner, L., & Angwin, J. (2016). <a href='https://www.propublica.org/article/how-we-analyzed-the-compas-recidivism-algorithm/'>How We Analyzed the COMPAS Recidivism Algorithm.</a> ProPublica."
     ],
     "source": "<a href='https://github.com/propublica/compas-analysis'>ProPublica GitHub Repository</a>",
     "url": "https://datasets.biolab.si/core/compas-scores-two-years.tab",


### PR DESCRIPTION
Changes to adult:
- Renamed the dataset from "Adult" to "Adult Census Income"
- Added the missing test part of the dataset
- Added a meta feature showing if the instance is from the training or testing dataset
- Renamed "sex" feature to "gender"
- Renamed "y" feature/target to "income"
- Renamed the "White" and "Black" values of the "race" feature to "Caucasian" and "African-American"
- Renamed the "<=50K" value of the "income" feature to "≤50K"

Changes to Compas:
- Fixed the references to include a citation in addition to a working hyperlink