### PR TITLE
Removing the meta test-split column from Adult dataset

### DIFF
--- a/core/adult.tab.info
+++ b/core/adult.tab.info
@@ -7,9 +7,9 @@
     "variables": 15,
     "missing": true,
     "target": "categorical",
-    "size": 5860112,
+    "size": 5583314,
     "year": 1996,
-    "version": "1.2",
+    "version": "1.3",
     "tags": [
         "economy",
         "fairness"
@@ -18,6 +18,6 @@
         "Ron Kohavi (1996) Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid. Proceedings of the Second International Conference on Knowledge Discovery and Data Mining."
     ],
     "source": "<a href='https://archive.ics.uci.edu/ml/datasets/adult'>UCI ML Repository</a>",
-    "url": "https://datasets.biolab.si/core/adult.tab",
+    "url": "https://www.dropbox.com/scl/fi/ujk15mx0pox5lb0hm3zog/adult_new.tab?rlkey=tgt42mb3q7dxwq177qnfx9to2&dl=1",
     "seealso": []
 }


### PR DESCRIPTION
Changes to adult:
- Removed a meta feature showing if the instance is from the training or testing dataset